### PR TITLE
change the pillow version because the previous one could not be installed

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -75,7 +75,7 @@ programs =
     10 openerp_connector_worker "${buildout:directory}/bin/python_openerp" [ "${buildout:directory}/parts/connector/connector/openerp-connector-worker" --config="${buildout:directory}/etc/openerp.cfg"  --logfile "${:logfile_openerp_connector}" --workers=${:connector_workers} --limit-time-real=10800] ${buildout:directory} true
 
 [versions]
-Pillow = 1.7.7
+Pillow = 2.3.0
 PyXML = 0.8.4
 babel = 1.3
 coverage = 3.7


### PR DESCRIPTION
While executing bin/buildout, I got that error:

```
error: Setup script exited with error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
An error occurred when trying to install Pillow 1.7.7. Look above this message for any errors that were output by easy_install.
anybox.recipe.openerp.base: Could not find or install '1.7.7'.  Original exception zc.buildout.UserError says: Couldn't install: Pillow 1.7.7
While:
  Updating openerp.
Error: Couldn't install: Pillow 1.7.7
```

So, the fix proposed is similar to what was done with babel in the previous commit (ba1f90f)
